### PR TITLE
Raise error if pandoc does not return success (requires ruby 1.9.3+)

### DIFF
--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -208,12 +208,15 @@ private
 
   # Runs the command and returns the output.
   def execute(command)
-    output = ''
-    Open3::popen3(command) do |stdin, stdout, stderr| 
+    output = error = exit_status = nil
+    Open3::popen3(command) do |stdin, stdout, stderr, wait_thr|
       stdin.puts @target 
       stdin.close
       output = stdout.read 
+      error = stderr.read
+      exit_status = wait_thr.value
     end
+    raise error unless exit_status.success?
     output
   end
 


### PR DESCRIPTION
At the moment if pandoc fails (e.g. you pass invalid options) then pandoc-ruby silently returns an empty string with no indication of the error. This patch detects the return code and raises an error if it is non-zero.

~~~
$ irb20 -Ilib
irb(main):001:0> require 'pandoc-ruby'
=> true
irb(main):002:0> PandocRuby.new("# hello", "badopt").to_html5
RuntimeError: pandoc: unrecognized option `--badopt'
Try pandoc --help for more information.

	from /Users/brian/git/pandoc-ruby/lib/pandoc-ruby.rb:219:in `execute'
	from /Users/brian/git/pandoc-ruby/lib/pandoc-ruby.rb:201:in `convert_string'
	from /Users/brian/git/pandoc-ruby/lib/pandoc-ruby.rb:135:in `convert'
	from /Users/brian/git/pandoc-ruby/lib/pandoc-ruby.rb:169:in `block (2 levels) in <class:PandocRuby>'
	from (irb):2
	from /usr/local/bin/irb20:12:in `<main>'
~~~
