### PR TITLE
Allow first argument to be an array of file paths

### DIFF
--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -1,6 +1,5 @@
 require 'open3'
 require 'tempfile'
-require 'pry'
 
 class PandocRuby
 
@@ -99,16 +98,22 @@ class PandocRuby
   attr_accessor :writer
   def writer; @writer || 'html' end
 
-  # Create a new PandocRuby converter object. The first argument should be
-  # the string that will be converted or, if `.allow_file_paths` has been set
-  # to `true`, this can also be a path to a file. The executable name can
-  # be used as the second argument, but will default to `pandoc` if the second
-  # argument is omitted or anything other than an executable name. Any other
-  # arguments will be converted to pandoc options.
+  # Create a new PandocRuby converter object. The first argument should be the
+  # string that will be converted or, if `.allow_file_paths` has been set to
+  # `true`, this can also be a path to a file (or an array of file paths). The
+  # executable name can be used as the second argument, but will default to
+  # `pandoc` if the second argument is omitted or anything other than an
+  # executable name. Any other arguments will be converted to pandoc options.
   def initialize(*args)
     target = args.shift
-    @target = if @@allow_file_paths && File.exists?(target)
+    @target = if @@allow_file_paths && target.is_a?(String) && File.exists?(target)
       File.read(target)
+    elsif @@allow_file_paths && target.is_a?(Array)
+      target_string = ""
+      target.each do | file_path |
+        target_string << File.read(file_path)
+      end
+      target_string
     else
       target rescue target
     end

--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -109,11 +109,11 @@ class PandocRuby
     @target = if @@allow_file_paths && target.is_a?(String) && File.exists?(target)
       File.read(target)
     elsif @@allow_file_paths && target.is_a?(Array)
-      target_string = ""
+      target_strings = []
       target.each do | file_path |
-        target_string << File.read(file_path)
+        target_strings << File.read(file_path)
       end
-      target_string
+      target_strings.join("\n\n")
     else
       target rescue target
     end

--- a/test/test_conversions.rb
+++ b/test/test_conversions.rb
@@ -41,7 +41,7 @@ class TestConversions < Test::Unit::TestCase
     h[:mediawiki] =
       %Q|= This is a Title =\n\nSome ''emphasized text'' and [http://daringfireball.net/projects/markdown/ a link]|
     h[:textile] =
-      %Q|h1. This is a Title\n\nSome _emphasized text_ and \"a link\":http://daringfireball.net/projects/markdown/|
+      %Q|h1(#this-is-a-title). This is a Title\n\nSome _emphasized text_ and \"a link\":http://daringfireball.net/projects/markdown/|
     h[:rtf] =
       %Q|{\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs36 This is a Title\\par}\n{\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 Some {\\i emphasized text} and {\\field{\\*\\fldinst{HYPERLINK \"http://daringfireball.net/projects/markdown/\"}}{\\fldrslt{\\ul\na link\n}}}\n\\par}|
     h[:org] =

--- a/test/test_pandoc-ruby.rb
+++ b/test/test_pandoc-ruby.rb
@@ -38,8 +38,12 @@ class TestPandocRuby < Test::Unit::TestCase
 
   should "concatenate multiple files if provided an array" do
     PandocRuby.allow_file_paths = true
-    assert_match /This is a Title/, PandocRuby.new(@file_array).to_html
+    html_output = PandocRuby.new(@file_array).to_html
+
+    assert_match "This is a Title", html_output
+    assert_match "link</a></p>\n<h1", html_output
   end
+
   
 
   should "accept short options" do

--- a/test/test_pandoc-ruby.rb
+++ b/test/test_pandoc-ruby.rb
@@ -4,6 +4,7 @@ class TestPandocRuby < Test::Unit::TestCase
 
   def setup
     @file = File.join(File.dirname(__FILE__), 'files', 'test.md')
+    @file_array = [@file, @file]
     @converter = PandocRuby.new(@file, :t => :rst)
   end
 
@@ -35,6 +36,11 @@ class TestPandocRuby < Test::Unit::TestCase
     assert PandocRuby.new(@file).to_html.match(%r{This is a Title})
   end
 
+  should "concatenate multiple files if provided an array" do
+    PandocRuby.allow_file_paths = true
+    assert_match /This is a Title/, PandocRuby.new(@file_array).to_html
+  end
+  
 
   should "accept short options" do
     @converter.expects(:execute).with('pandoc -t rst').returns(true)


### PR DESCRIPTION
Rather than being limited to submitting a string or a single file to
PandocRuby, this accepts an array of file paths as well. All of the
files are read and concatenated into a single document.

Fixes alphabetum/pandoc-ruby#4.