### PR TITLE
Add timeout option for out-of-control pandoc jobs

### DIFF
--- a/test/files/bomb.tex
+++ b/test/files/bomb.tex
@@ -1,0 +1,23 @@
+\documentclass{article}
+\renewcommand*\familydefault{\sfdefault}
+
+\makeatletter
+
+\newcommand{\bomb@anglex}{0}
+\newcommand{\bomb@scalex}{1}
+\newcommand{\bomb@shaded}{N}
+\newcommand{\bomb@shadecolor}{black}
+\newcommand{\bomb@shadeperc}{25}
+\newcommand{\bomb@emphedge}{N}
+\newcommand{\bomb@emphstyle}{thick}
+\newcommand{\bomb}{
+  \bomb@shadecolor \bomb@shaded
+}
+
+
+\begin{document}
+
+\bomb
+
+\end{document}
+

--- a/test/test_pandoc-bomb.rb
+++ b/test/test_pandoc-bomb.rb
@@ -1,0 +1,20 @@
+require 'helper'
+class TestPandocBombRuby < Test::Unit::TestCase
+  def setup
+  end
+
+  def teardown
+  end
+
+  should "gracefully time out when bombed" do
+    file = File.join(File.dirname(__FILE__), 'files', 'bomb.tex')
+    contents = File.read(file)
+    error = nil
+    
+    assert_raise(RuntimeError) do
+      PandocRuby.convert(contents, :from => :latex, :to => :html, :timeout => 1)
+    end
+
+  end
+
+end


### PR DESCRIPTION
During our production use of the PandocRuby wrapper at Authorea (www.authorea.com) we have been hitting the occasional out-of-control pandoc job. 

While we are pretty sure the pandoc team will eventually resolve each individual problem, the general possibility for an unforeseen problem is always there (look at the extremely weird bomb.tex in this PR for one current example). 

So in this PR I am proposing a Ruby-level timeout option, which does a dirty -9 kill to the pandoc process if it has not terminated in the allotted time. It is a pretty standard technique for wrappers, though I wish pandoc supported a ```--timeout``` switch natively.

Let me know what you think about this PR, I would be happy to refactor it to your liking.

And thanks for the handy wrapper!