### PR TITLE
Fix test warnings, consistently wrap pandoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,14 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    json (1.8.3)
     metaclass (0.0.4)
-    minitest (5.8.3)
+    minitest (5.8.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    rake (10.4.2)
-    rdoc (4.2.0)
+    rake (11.1.2)
+    rdoc (4.2.2)
+      json (~> 1.4)
 
 PLATFORMS
   ruby
@@ -18,4 +20,4 @@ DEPENDENCIES
   rdoc
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -73,22 +73,22 @@ class PandocRuby
 
   attr_accessor :options
   def options
-    @options || []
+    @options ||= []
   end
 
   attr_accessor :option_string
   def option_string
-    @option_string || ''
+    @option_string ||= ''
   end
 
   attr_accessor :binary_output
   def binary_output
-    @binary_output || false
+    @binary_output ||= false
   end
 
   attr_accessor :writer
   def writer
-    @writer || 'html'
+    @writer ||= 'html'
   end
 
   # Create a new PandocRuby converter object. The first argument contains the
@@ -101,6 +101,9 @@ class PandocRuby
   #   new(["/path/to/file.md"], :option1 => :value, :option2)
   #   new(["/to/file1.html", "/to/file2.html"], :option1 => :value)
   def initialize(*args)
+    @input_files = nil
+    @input_string = nil
+
     if args[0].is_a?(String)
       @input_string = args.shift
     elsif args[0].is_a?(Array)
@@ -174,7 +177,7 @@ class PandocRuby
       begin
         self.options += [{ :output => tmp_file.path }]
         self.option_string = "#{self.option_string} --output #{tmp_file.path}"
-        execute("#{@@pandoc_path}#{self.option_string}")
+        execute_pandoc
         return IO.binread(tmp_file)
       ensure
         tmp_file.close
@@ -184,6 +187,11 @@ class PandocRuby
 
     # Execute the pandoc command for string writers.
     def convert_string
+      execute_pandoc
+    end
+
+    # Wrapper to run pandoc in a consistent, DRY way
+    def execute_pandoc
       if ! @input_files.nil?
         execute("#{@@pandoc_path} #{@input_files}#{self.option_string}")
       else

--- a/test/test_pandoc_ruby.rb
+++ b/test/test_pandoc_ruby.rb
@@ -40,6 +40,10 @@ describe PandocRuby do
     assert PandocRuby.new([@file, @file2]).to_html.match(/A Second Title/)
   end
 
+  it 'converts multiple element array input as array of file paths to a binary output format' do
+    assert PandocRuby.new([@file, @file2]).to_epub.match(/com.apple.ibooks/)
+  end
+
   it 'accepts short options' do
     @converter.expects(:execute).with('pandoc -t rst').returns(true)
     assert @converter.convert


### PR DESCRIPTION
@alphabetum I fixed a big where strings and binary output weren't consistently getting input files as an array (specifically, you couldn't pass an array of input files to binary output).

I've abstracted the common logic into the 'execute_pandoc' wrapper around execute.

I also noticed a huge number of warnings in the tests, which I fixed. The lockfile was corrupted, so I fixed that too.

Is there travis CI for this project? The project seems to be a little bit abandoned, do you still want to maintain?