### PR TITLE
whitelist options accepted by pandoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,12 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.8.3)
     metaclass (0.0.4)
-    minitest (5.8.4)
+    minitest (5.8.5)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    rake (11.1.2)
-    rdoc (4.2.2)
-      json (~> 1.4)
+    rake (12.0.0)
+    rdoc (5.0.0)
 
 PLATFORMS
   ruby
@@ -20,4 +18,4 @@ DEPENDENCIES
   rdoc
 
 BUNDLED WITH
-   1.12.2
+   1.12.5

--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -101,6 +101,11 @@ class PandocRuby
     @options ||= []
   end
 
+  attr_writer :ignore_whitelist
+  def ignore_whitelist
+    @ignore_whitelist
+  end
+
   attr_writer :option_string
   def option_string
     @option_string ||= ''
@@ -130,6 +135,7 @@ class PandocRuby
       self.input_files = args.shift.join(' ')
     end
     self.options = args
+    self.ignore_whitelist = self.options.find { |o| o == :ignore_whitelist }
   end
 
   # Run the conversion. The convert method can take any number of arguments,
@@ -265,9 +271,11 @@ class PandocRuby
     # command line options. If the option has an argument, it is also included.
     # Only whitelisted options are sent to pandoc.
     def create_option(flag, argument = nil)
-      return '' unless flag && ALLOWED_OPTIONS.include?(flag.to_s.gsub('_', '-'))
+      return '' unless flag
       flag = flag.to_s
       set_pandoc_ruby_options(flag, argument)
+      return '' unless @ignore_whitelist ||
+                       ALLOWED_OPTIONS.include?(flag.gsub('_', '-'))
       if !argument.nil?
         "#{format_flag(flag)} #{argument}"
       else
@@ -292,6 +300,8 @@ class PandocRuby
       when 't', 'to'
         self.writer = argument.to_s
         self.binary_output = true if BINARY_WRITERS.keys.include?(self.writer)
+      when 'timeout'
+        @timeout = argument
       end
     end
 

--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -57,6 +57,26 @@ class PandocRuby
   # All of the available Writers.
   WRITERS = STRING_WRITERS.merge(BINARY_WRITERS)
 
+  # Options understood by pandoc, taken from http://pandoc.org/MANUAL.html.
+  # Ignore all other options passed to pandoc
+  AVAILABLE_OPTIONS = Set.new %w(from read to write output data-dir strict
+    parse-raw smart old-dashes base-header-level indented-code-classes filter
+    normalize preserve-tabs tab-stop track-changes extract-media standalone
+    template metadata variable print-default-template print-default-data-file
+    no-wrap columns toc table-of-contents toc-depth no-highlight
+    highlight-style include-in-header include-before-body include-after-body
+    self-contained offline html5 html-q-tags ascii reference-links atx-headers
+    chapters number-sections number-offsetS no-tex-ligatures listings
+    incremental slide-level section-divs default-image-extension
+    email-obfuscation id-prefix title-prefix css reference-odt reference-docx
+    epub-stylesheet epub-cover-image epub-metadata epub-embed-font
+    epub-chapter-level latex-engine latex-engine-opt bibliography csl
+    citation-abbreviations natbib biblatex latexmathml asciimathml mathml
+    mimetex webtex jsmath mathjax katex katex-stylesheet gladtex trace
+    dump-args ignore-args verbose bash-completion)
+  ALIAS_OPTIONS = Set.new %w(f r t w o R S F p s M V D H B A 5 N i T c m)
+  ALLOWED_OPTIONS = AVAILABLE_OPTIONS + ALIAS_OPTIONS
+
   # To use run the pandoc command with a custom executable path, the path
   # to the pandoc executable can be set here.
   def self.pandoc_path=(path)
@@ -243,11 +263,11 @@ class PandocRuby
     # Takes a flag and optional argument, uses it to set any relevant options
     # used by the library, and returns string with the option formatted as a
     # command line options. If the option has an argument, it is also included.
+    # Only whitelisted options are sent to pandoc.
     def create_option(flag, argument = nil)
-      return '' unless flag
+      return '' unless flag && ALLOWED_OPTIONS.include?(flag.to_s.gsub('_', '-'))
       flag = flag.to_s
       set_pandoc_ruby_options(flag, argument)
-      return '' if flag == 'timeout' # pandoc doesn't accept timeouts yet
       if !argument.nil?
         "#{format_flag(flag)} #{argument}"
       else
@@ -272,8 +292,6 @@ class PandocRuby
       when 't', 'to'
         self.writer = argument.to_s
         self.binary_output = true if BINARY_WRITERS.keys.include?(self.writer)
-      when 'timeout'
-        @timeout = argument
       end
     end
 

--- a/test/test_pandoc_ruby.rb
+++ b/test/test_pandoc_ruby.rb
@@ -92,12 +92,6 @@ describe PandocRuby do
     assert converter.convert
   end
 
-  it 'raises RuntimeError from pandoc executable error' do
-    assert_raises(RuntimeError) do
-      PandocRuby.new('# hello', 'badopt').to_html5
-    end
-  end
-
   PandocRuby::READERS.each_key do |r|
     it "converts from #{r} with PandocRuby.#{r}" do
       converter = PandocRuby.send(r, @string)
@@ -149,17 +143,6 @@ describe PandocRuby do
       assert true
     rescue Errno::EMFILE, Errno::EAGAIN => e
       flunk e
-    end
-  end
-
-  it 'gracefully times out when pandoc hangs due to malformed input' do
-    file = File.join(File.dirname(__FILE__), 'files', 'bomb.tex')
-    contents = File.read(file)
-
-    assert_raises(RuntimeError) do
-      PandocRuby.convert(
-        contents, :from => :latex, :to => :html, :timeout => 1
-      )
     end
   end
 


### PR DESCRIPTION
This pull requests whitelists the options sent to pandoc instead of raising a RuntimeError. This makes it much easier to integrate `pandoc-ruby` with other libraries, specifically tilt (https://github.com/rtomayko/tilt/pull/297), which in turn is used by other libraries. The whitelist can be overridden with the `:ignore_whitelist` option. An alternative would be to make the whitelist opt-in rather opt-out with a `:use_whitelist` option, but I feel that the default behavior could be to ignore unknown options rather than raising a RuntimeError.